### PR TITLE
Send more info on disconnected event

### DIFF
--- a/lib/firehose/consumer.coffee
+++ b/lib/firehose/consumer.coffee
@@ -83,13 +83,6 @@ class Consumer
         @config.connected = origConnected
         origConnected()
 
-  #  origDisconnected = @config.disconnected
-  #  @config.disconnected = =>
-  #    deferred.reject()
-  #    if origDisconnected
-  #      @config.disconnected = origDisconnected
-  #      origDisconnected()
-
     deferred.promise()
 
 Consumer.multiplexChannel = "channels@firehose"

--- a/lib/firehose/long_poll_transport.coffee
+++ b/lib/firehose/long_poll_transport.coffee
@@ -108,7 +108,7 @@ class LongPollTransport extends Transport
 
     unless @_needToNotifyOfReconnect or @_stopRequestLoop
       @_needToNotifyOfReconnect = true
-      @config.disconnected()
+      @config.disconnected(jqXhr, status, error)
     unless @_stopRequestLoop
       # Ping the server to make sure this isn't a network connectivity error
       setTimeout @_ping, @_retryDelay + @_lagTime

--- a/lib/firehose/transport.coffee
+++ b/lib/firehose/transport.coffee
@@ -26,7 +26,7 @@ class Transport
   _error: (event) =>
     if @_succeeded
       # Lets try to connect again with delay
-      @config.disconnected()
+      @config.disconnected event
       @connect(@_retryDelay)
     else @config.failed event
 
@@ -37,7 +37,7 @@ class Transport
 
   # Default connection closed handler
   _close: (event) =>
-    @config.disconnected()
+    @config.disconnected event
 
   # Useful for reconnecting after any networking hiccups
   getLastMessageSequence: =>

--- a/lib/firehose/web_socket_transport.coffee
+++ b/lib/firehose/web_socket_transport.coffee
@@ -90,7 +90,7 @@ class WebSocketTransport extends Transport
     @_cleanUp()
     if @_needToNotifyOfDisconnect
       @_needToNotifyOfDisconnect = false
-      @config.disconnected()
+      @config.disconnected event
     if @_succeeded
       @connect @_retryDelay
     else if @config.failed


### PR DESCRIPTION
We don't currently send any data to the `disconnected` handler. In order to debug, I'd like to send more information along to the help identify disconnects. Specifically, I'm looking for `CloseEvent.close` and `CloseEvent.reason` from http://stackoverflow.com/questions/18803971/websocket-onerror-how-to-read-error-description