### PR TITLE
Use last_message_sequence over message_sequence in Firehose protocol

### DIFF
--- a/lib/firehose/multiplexed_web_socket.coffee
+++ b/lib/firehose/multiplexed_web_socket.coffee
@@ -8,7 +8,7 @@ class MultiplexedWebSocket extends WebSocketTransport
     @_sendMessage
       multiplex_subscribe:
         channel: channel
-        message_sequence: opts.last_sequence
+        last_message_sequence: opts.last_sequence
 
   unsubscribe: (channelNames...) =>
     @_sendMessage

--- a/lib/firehose/web_socket_transport.coffee
+++ b/lib/firehose/web_socket_transport.coffee
@@ -61,10 +61,10 @@ class WebSocketTransport extends Transport
         @sendStartingMessageSequence @_lastMessageSequence
       else @config.webSocket.connectionVerified @
 
-  sendStartingMessageSequence: (message_sequence) =>
-    @_lastMessageSequence = message_sequence
+  sendStartingMessageSequence: (last_message_sequence) =>
+    @_lastMessageSequence = last_message_sequence
     @socket.onmessage     = @_message
-    @_sendMessage({message_sequence})
+    @_sendMessage({last_message_sequence})
     @_needToNotifyOfDisconnect = true
     Transport::_open.call @
 


### PR DESCRIPTION
'message_sequence' has been deprecated in the protocol in favor of 'last_message_sequence'.