### PR TITLE
Allow synchronous connection

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -23,7 +23,14 @@ class Transport {
   // Lets rock'n'roll! Connect to the server.
   connect(delay) {
     if (delay == null) { delay = 0; }
-    setTimeout(this._request, delay);
+
+    if (delay >= 0) {
+      setTimeout(this._request, delay);
+    } else {
+      // Allow synchronous connection if -1 is passed
+      this._request()
+    }
+
     return this;
   }
 

--- a/spec/transport_spec.js
+++ b/spec/transport_spec.js
@@ -16,7 +16,7 @@ describe('Transport', function() {
     it('sets a retry delay',      function() { expect( this.instance._retryDelay ).toEqual(jasmine.any(Number)); });
   });
 
-  describe('#connect', () =>
+  describe('#connect', () => {
     describe('when given a 500 delay', function() {
       beforeEach(function() {
         jasmine.clock().install()
@@ -25,7 +25,7 @@ describe('Transport', function() {
       });
 
       afterEach(function() {
-       jasmine.clock().uninstall()
+        jasmine.clock().uninstall()
         this.instance._request.calls.reset()
       })
 
@@ -39,5 +39,20 @@ describe('Transport', function() {
         expect( this.instance._request ).toHaveBeenCalled()
       });
     })
-  );
+
+    describe('when given a -1` delay', function() {
+      beforeEach(function() {
+        spyOn(this.instance, '_request')
+        this.instance.connect(-1);
+      })
+
+      afterEach(function() {
+        this.instance._request.calls.reset()
+      })
+
+      it('calls _request immediately', function() {
+        expect(this.instance._request).toHaveBeenCalled()
+      })
+    })
+  });
 });


### PR DESCRIPTION
Without going nuts on a much needed rewrite, let's try to deal with some of these issues incrementally. This change allows the consumer to connect immediately rather than wait for the next tick of the event loop. 